### PR TITLE
[NLU-3] Drag to select calendar UX

### DIFF
--- a/src/components/calendar/Day.vue
+++ b/src/components/calendar/Day.vue
@@ -2,6 +2,7 @@
 
 	import Increment from './Increment.vue'
 	import DayModel from '../../models/DayModel'
+	import { reactive } from 'vue'
 
 	// TODO: architecture?? MVVM?
 	export interface Props {
@@ -14,12 +15,72 @@
 	// TODO: handle relative index reactive click from Increment component
 	// and bubble up to Calendar component as a unified (i.e., selected) range
 
+	const emit = defineEmits(['intersects'])
+
+	let dragging: boolean = false
+
+	// Using for O(1) even tho vals are not semantically important
+	// (i.e., .exists() would work just as fine)
+	let intersections = reactive(new Map())
+
+	function mousedown(event) {
+		dragging = true
+		console.log("mousedown")
+	}
+
+	function mouseup(event) {
+		dragging = false
+		console.log("mouseup")
+	}
+
+
+	// MARK: Intersection
+	// These are mouse events we explicitly listen to the child for
+	// to avoid intersection calculations
+
+	function childMouseenter(index) {
+		if (!dragging) { return }
+
+		// if already selected, toggle to unselected
+		// TODO: boolean zen
+		if (intersections.get(index)) {
+			intersections.set(index, false)
+		} else {
+			console.log("set " + index + " to true")
+			console.log(intersections)
+			intersections.set(index, true)
+		}
+	}
+
+	function childMousedown(index) {
+		console.log("clicked on " + intersections.get(index))
+		intersections.set(index, !intersections.get(index))
+	}
+
+	function childClick(index) {
+
+	}
+
+
+
 </script>
 
 <template>
-    <div class="day">
+
+    <div
+		class="day"
+		@mousedown="mousedown"
+		@mouseup="mouseup"
+	>
     	<h3>{{ dayModel.name }}</h3>
-		<Increment v-for="(n, i) in timeRangeLength" :index="i"/>
+		<Increment
+			v-for="(n, i) in timeRangeLength"
+			:index="i"
+			@child-mouseenter="childMouseenter"
+			@child-mousedown="childMousedown"
+			@child-click="childClick"
+			:class="{ selectedElement: intersections.get(i) }"
+		/>
 	</div>
 </template>
 
@@ -28,6 +89,12 @@
 	.day {
 		display: grid;
 		row-gap: 5px;
+	}
+
+	// The selected "day" element
+	.selectedElement {
+		background-color: #FC7753 !important;
+		color: black;
 	}
 
 	h3 {

--- a/src/components/calendar/Day.vue
+++ b/src/components/calendar/Day.vue
@@ -12,12 +12,15 @@
 
 	const props = defineProps<Props>()
 	const emit = defineEmits(['intersects'])
+	let dragging = false
 
-	let dragging: boolean = false
-
-	// Using for O(1) even tho vals are not semantically important
-	// (i.e., .exists() would work just as fine)
-	let intersections = reactive(new Map())
+	// Key is index of the Increment that is selected (relative to each day col)
+	// Value is true/false if selected
+	// Map with boolean vals is used for O(1) (.exists() is semantically equivalent)
+	let intersections: Map<number, boolean> = reactive(new Map())
+	for (var i = 0; i < props.timeRangeLength; i++) {
+		intersections.set(i, false)
+	}
 
 	function mousedown(event: Event) {
 		dragging = true
@@ -62,7 +65,7 @@
 	>
     	<h3>{{ dayModel.name }}</h3>
 		<Increment
-			v-for="(n, i) in timeRangeLength"
+			v-for="i in timeRangeLength"
 			:index="i"
 			@child-mouseenter="childMouseenter"
 			@child-mousedown="childMousedown"

--- a/src/components/calendar/Day.vue
+++ b/src/components/calendar/Day.vue
@@ -19,18 +19,18 @@
 	// (i.e., .exists() would work just as fine)
 	let intersections = reactive(new Map())
 
-	function mousedown(event) {
+	function mousedown(event: Event) {
 		dragging = true
 		// Skip default behavior to prevent edit cursor in Safari
 		// src: https://stackoverflow.com/a/9743380/1431900
 		event.preventDefault()
 	}
 
-	function mouseup(event) {
+	function mouseup(event: Event) {
 		dragging = false
 	}
 
-	function mouseleave(event) {
+	function mouseleave(event: Event) {
 		dragging = false
 	}
 
@@ -39,14 +39,14 @@
 	// These are mouse events we explicitly listen to the child for
 	// to avoid intersection calculations
 
-	function childMouseenter(index) {
+	function childMouseenter(index: number) {
 		if (!dragging) { return }
 		// Toggle
 		const selected = intersections.get(index)
 		intersections.set(index, !selected)
 	}
 
-	function childMousedown(index) {
+	function childMousedown(index: number) {
 		intersections.set(index, !intersections.get(index))
 	}
 

--- a/src/components/calendar/Day.vue
+++ b/src/components/calendar/Day.vue
@@ -91,6 +91,7 @@
 
 	// The selected "day" element
 	.selectedElement {
+		transition: 0.05s background-color;
 		background-color: #FC7753 !important;
 		color: black;
 	}

--- a/src/components/calendar/Day.vue
+++ b/src/components/calendar/Day.vue
@@ -21,7 +21,6 @@
 
 	function mousedown(event) {
 		dragging = true
-		console.log("mousedown")
 		// Skip default behavior to prevent edit cursor in Safari
 		// src: https://stackoverflow.com/a/9743380/1431900
 		event.preventDefault()
@@ -29,7 +28,6 @@
 
 	function mouseup(event) {
 		dragging = false
-		console.log("mouseup")
 	}
 
 	function mouseleave(event) {
@@ -37,26 +35,18 @@
 	}
 
 
-	// MARK: Intersection
+	// MARK: Intersection & child events
 	// These are mouse events we explicitly listen to the child for
 	// to avoid intersection calculations
 
 	function childMouseenter(index) {
 		if (!dragging) { return }
-
-		// if already selected, toggle to unselected
-		// TODO: boolean zen
-		if (intersections.get(index)) {
-			intersections.set(index, false)
-		} else {
-			console.log("set " + index + " to true")
-			console.log(intersections)
-			intersections.set(index, true)
-		}
+		// Toggle
+		const selected = intersections.get(index)
+		intersections.set(index, !selected)
 	}
 
 	function childMousedown(index) {
-		console.log("clicked on " + intersections.get(index))
 		intersections.set(index, !intersections.get(index))
 	}
 

--- a/src/components/calendar/Day.vue
+++ b/src/components/calendar/Day.vue
@@ -11,10 +11,6 @@
 	}
 
 	const props = defineProps<Props>()
-
-	// TODO: handle relative index reactive click from Increment component
-	// and bubble up to Calendar component as a unified (i.e., selected) range
-
 	const emit = defineEmits(['intersects'])
 
 	let dragging: boolean = false
@@ -26,11 +22,18 @@
 	function mousedown(event) {
 		dragging = true
 		console.log("mousedown")
+		// Skip default behavior to prevent edit cursor in Safari
+		// src: https://stackoverflow.com/a/9743380/1431900
+		event.preventDefault()
 	}
 
 	function mouseup(event) {
 		dragging = false
 		console.log("mouseup")
+	}
+
+	function mouseleave(event) {
+		dragging = false
 	}
 
 
@@ -57,12 +60,6 @@
 		intersections.set(index, !intersections.get(index))
 	}
 
-	function childClick(index) {
-
-	}
-
-
-
 </script>
 
 <template>
@@ -71,6 +68,7 @@
 		class="day"
 		@mousedown="mousedown"
 		@mouseup="mouseup"
+		@mouseleave="mouseleave"
 	>
     	<h3>{{ dayModel.name }}</h3>
 		<Increment
@@ -78,7 +76,6 @@
 			:index="i"
 			@child-mouseenter="childMouseenter"
 			@child-mousedown="childMousedown"
-			@child-click="childClick"
 			:class="{ selectedElement: intersections.get(i) }"
 		/>
 	</div>
@@ -89,6 +86,7 @@
 	.day {
 		display: grid;
 		row-gap: 5px;
+		user-select: none;
 	}
 
 	// The selected "day" element

--- a/src/components/calendar/Increment.vue
+++ b/src/components/calendar/Increment.vue
@@ -32,7 +32,7 @@
 		user-select: none;
 
 		&:hover {
-			background-color: #C95F42;
+			background-color: lighten(#FC7753, 10%);
 		}
 	}
 

--- a/src/components/calendar/Increment.vue
+++ b/src/components/calendar/Increment.vue
@@ -5,7 +5,7 @@
 	import { ref } from 'vue'
 
 	export interface Props {
-		index: number // index that was selected
+		index: number
 	}
 	const props = defineProps<Props>()
 
@@ -13,7 +13,6 @@
 </script>
 
 <template>
-
 	<!-- Events are for parent ("Day") to listen to -->
 	<div
 		class="increment"

--- a/src/components/calendar/Increment.vue
+++ b/src/components/calendar/Increment.vue
@@ -7,16 +7,20 @@
 	export interface Props {
 		index: number // index that was selected
 	}
-	const selected = ref(false)
+	const props = defineProps<Props>()
 
-	function toggleSelected() {
-		selected.value = !selected.value
-	}
 
 </script>
 
 <template>
-	<div class="increment" @click="toggleSelected" :class="selected && 'active'"></div>
+
+	<!-- Events are for parent ("Day") to listen to -->
+	<div
+		class="increment"
+		@mouseenter="$emit('child-mouseenter', index)"
+		@mousedown="$emit('child-mousedown', index)"
+		@click="$emit('child-click', index)"
+	></div>
 </template>
 
 <style scoped lang="scss">
@@ -28,13 +32,9 @@
 		transition: 0.02s background-color;
 
 		&:hover {
-			background-color: #FC7753;
+			background-color: #C95F42;
 		}
 
-	}
-
-	.active {
-		background-color: rgba(blue, 0.5);
 	}
 
 </style>

--- a/src/components/calendar/Increment.vue
+++ b/src/components/calendar/Increment.vue
@@ -19,7 +19,6 @@
 		class="increment"
 		@mouseenter="$emit('child-mouseenter', index)"
 		@mousedown="$emit('child-mousedown', index)"
-		@click="$emit('child-click', index)"
 	></div>
 </template>
 
@@ -30,11 +29,11 @@
 		background-color: white;
 		height: 40px;
 		transition: 0.02s background-color;
+		user-select: none;
 
 		&:hover {
 			background-color: #C95F42;
 		}
-
 	}
 
 </style>


### PR DESCRIPTION
## Background

Implements drag to select functionality for #3.
The data model is easy to extract after this -- just pulling all `true` values from the `intersections` map.

Styling improvements are for future PRs :-)
Note to test on multiple browsers!

## Contents
- Parent/child event emitting for intersections
- Parent filtering for drag events

## Preview
https://user-images.githubusercontent.com/2782749/213899120-2b0c3f9e-e064-4335-b6b1-31e40a788059.mp4

