### PR TITLE
[NLU-42] Calendar spacing to match Figma; am/pm legend

### DIFF
--- a/src/components/calendar/Calendar.vue
+++ b/src/components/calendar/Calendar.vue
@@ -27,7 +27,7 @@
 	}
 
 	// TODO: Make computed, didn't do it because <vague compiler complaints>
-	function timeRange(): number[] {
+	function timeRangeDisplay(): string[] {
 		// Create a range of hours that can be returned
 		// For instance, if our prop is
 		//		startTime: 9am
@@ -35,24 +35,32 @@
 		// This method would return
 		//		[9, 10, 11, 12, 1, 2, 3, 4]
 
-		let hours: number[] = []
+		let hours: string[] = []
 
 		const startHour = props.startTime.getHours()
 		const endHour = props.endTime.getHours()
 
+		// Crosses over
 		if (isMorning(startHour) && isAfternoon(endHour)) {
 			for (var i = startHour; i <= 12; i++) {
-				hours.push(i)
+				hours.push(i + "am")
 			}
 			// Start at "1" that gets converted
 			for (var i = 13; i <= endHour; i++) {
-				hours.push(i - 12)
+				hours.push((i - 12) + "pm")
 			}
+
+		// All morning or all afternoon
 		} else {
-			hours.push(-1)
+			hours.push(-1 + "??")
 			// Loop directly
 			for (var i = startHour; i <= endHour; i++) {
-				hours.push(i)
+
+				if (isMorning(i)) {
+					hours.push(i + "am")
+				} else {
+					hours.push(i + "pm")
+				}
 			}
 		}
 
@@ -63,7 +71,7 @@
 	// Used for ranges of the calendar page
 
 	const timeRangeLength = computed<number>(() => {
-		return timeRange().length * 2
+		return timeRangeDisplay().length * 2
 	})
 
 	const dayRangeLength = computed<number>(() => {
@@ -81,7 +89,7 @@
 			<div id="legend">
 				<!-- Dummy first node to leave space for header -->
 				<p></p>
-				<p v-for="(hour, i) in timeRange()">{{ hour }}</p>
+				<p v-for="(hour, i) in timeRangeDisplay()">{{ hour }}</p>
 			</div>
 			<Day v-for="(day, i) in dayModels" :dayModel="day" :timeRangeLength="timeRangeLength" />
 		</div>

--- a/src/components/calendar/Calendar.vue
+++ b/src/components/calendar/Calendar.vue
@@ -94,7 +94,7 @@
 			<Day v-for="(day, i) in dayModels" :dayModel="day" :timeRangeLength="timeRangeLength" />
 		</div>
 	</div>
-	<Footer />
+	<!-- <Footer /> -->
 </template>
 
 <style scoped lang="scss">
@@ -120,25 +120,29 @@
 		// as if its the first column.
 		// The first actual column is the legend.
 		&>div {
-			background-color: rgba(black, 0.2);
-			padding-right: 5px;
 
 			// Border radius only on edges of first & last "real" col
 			// (I can't believe this works...)
 			&:nth-child(2) {
-				border-radius: 8px 0 0 8px;
-				padding-left: 5px;
+				// needs to know it's the "second" col
+				// (first in list of days)
+				&::v-deep .incrementContainer {
+					border-radius: 8px 0 0 8px;
+					padding-left: 20px;
+				}
 			}
 
 			&:last-child {
-				border-radius: 0 8px 8px 0;
+				&::v-deep .incrementContainer {
+					border-radius: 0 8px 8px 0;
+					padding-right: 20px;
+				}
 			}
 		}
 
 		#legend {
 			display: grid;
 			grid-template-rows: repeat(v-bind('timeRangeLength'), 40px);
-			row-gap: 5px;
 			background-color: white;
 
 			p {
@@ -147,7 +151,7 @@
 				margin: 0;
 				// TODO: halfway thru first day height, eyeballing for now
 				padding-top: 12px;
-				background-color: $primary;
+				// background-color: $primary;
 				padding-right: 20px;
 				text-align: right;
 

--- a/src/components/calendar/Calendar.vue
+++ b/src/components/calendar/Calendar.vue
@@ -112,6 +112,8 @@
 		display: grid;
 		justify-content: center;
 
+		$outerPad: 12px;
+
 		// HACK: Style background for the calendar
 		// Since we can't style around row gaps,
 		// we need to do some manual... adjustments.
@@ -121,37 +123,47 @@
 		// The first actual column is the legend.
 		&>div {
 
-			// Border radius only on edges of first & last "real" col
-			// (I can't believe this works...)
+			&::v-deep .incrementContainer {
+				padding: $outerPad 0;
+			}
+
+			// First day col
 			&:nth-child(2) {
 				// needs to know it's the "second" col
 				// (first in list of days)
 				&::v-deep .incrementContainer {
 					border-radius: 8px 0 0 8px;
-					padding-left: 20px;
+					padding-left: $outerPad;
 				}
 			}
 
+			// Add spacing to inner elements
+			&:not(&:last-child) {
+				&::v-deep .incrementContainer {
+					padding-right: 5px;
+				}
+			}
+
+			// Last day col
 			&:last-child {
 				&::v-deep .incrementContainer {
 					border-radius: 0 8px 8px 0;
-					padding-right: 20px;
+					padding-right: $outerPad;
 				}
 			}
 		}
 
 		#legend {
 			display: grid;
+			row-gap: 5px;
 			grid-template-rows: repeat(v-bind('timeRangeLength'), 40px);
 			background-color: white;
+			user-select: none;
 
 			p {
+				// background-color: $primary;
 				grid-row: span 2;
 				font-size: 1.1rem;
-				margin: 0;
-				// TODO: halfway thru first day height, eyeballing for now
-				padding-top: 12px;
-				// background-color: $primary;
 				padding-right: 20px;
 				text-align: right;
 

--- a/src/components/calendar/Calendar.vue
+++ b/src/components/calendar/Calendar.vue
@@ -94,7 +94,7 @@
 			<div id="rightBgCol"></div>
 		</div>
 	</div>
-	<!-- <Footer /> -->
+	<Footer />
 </template>
 
 <style scoped lang="scss">

--- a/src/components/calendar/Calendar.vue
+++ b/src/components/calendar/Calendar.vue
@@ -101,6 +101,7 @@
 
 	#calContainer {
 		margin: 0 auto;
+		margin-top: 50px;
 		width: min(750px, 80%);
 	}
 
@@ -114,14 +115,19 @@
 		// HACK: Style background for the calendar
 		// Since we can't style around row gaps,
 		// we need to do some manual... adjustments.
+		//
+		// Key iea: style the second col, first day of week,
+		// as if its the first column.
+		// The first actual column is the legend.
 		&>div {
 			background-color: rgba(black, 0.2);
-			padding: 10px;
+			padding-right: 5px;
 
 			// Border radius only on edges of first & last "real" col
 			// (I can't believe this works...)
 			&:nth-child(2) {
 				border-radius: 8px 0 0 8px;
+				padding-left: 5px;
 			}
 
 			&:last-child {
@@ -135,14 +141,15 @@
 			row-gap: 5px;
 			background-color: white;
 
-			// Day cols
 			p {
 				grid-row: span 2;
 				font-size: 1.1rem;
 				margin: 0;
+				// TODO: halfway thru first day height, eyeballing for now
+				padding-top: 12px;
+				background-color: $primary;
 				padding-right: 20px;
 				text-align: right;
-				border-top: 1px solid black;
 
 				// Hidden empty first cell
 				// to match day of week name

--- a/src/components/calendar/Calendar.vue
+++ b/src/components/calendar/Calendar.vue
@@ -107,7 +107,7 @@
 	}
 
 	#calendar {
-		$outerPad: 12px;
+		$outerPad: 15px;
 		$innerPad: $outerPad / 2;
 
 		$legend-width: 10%;
@@ -118,7 +118,7 @@
 
 		// $innerPad is provided later
 		// to maintain consistent col width.
-		$bgColWidth: calc($outerPad - $innerPad);
+		$bgColWidth: calc($outerPad - calc($innerPad / 2));
 
 		// Note: two cols exclusively for background-color
 		grid-template-columns: $legend-width $bgColWidth repeat($dayRange, $dayWidth) $bgColWidth;
@@ -145,31 +145,9 @@
 			border-radius: 0 8px 8px 0;
 		}
 
-		&>div {
-
-			&::v-deep .incrementContainer {
-				// Account for doubling in inner cols
-				padding: $outerPad ($innerPad / 2);
-			}
-
-			// The following two padding adjustments
-			// help keep all cols the same width,
-			// as padding will shrink them.
-
-			// First day col
-			&:nth-child(3) {
-				// This is here b/c it needs to know it's the "second" col
-				&::v-deep .incrementContainer {
-					padding-left: $innerPad;
-				}
-			}
-
-			// Last day col
-			&:nth-last-child(2) {
-				&::v-deep .incrementContainer {
-					padding-right: $innerPad;
-				}
-			}
+		// Account for doubling in inner cols
+		&::v-deep .incrementContainer {
+			padding: $outerPad ($innerPad / 2);
 		}
 
 		#legend {

--- a/src/components/calendar/Calendar.vue
+++ b/src/components/calendar/Calendar.vue
@@ -52,7 +52,6 @@
 
 		// All morning or all afternoon
 		} else {
-			hours.push(-1 + "??")
 			// Loop directly
 			for (var i = startHour; i <= endHour; i++) {
 

--- a/src/components/calendar/Calendar.vue
+++ b/src/components/calendar/Calendar.vue
@@ -75,7 +75,6 @@
 	})
 
 	const dayRangeLength = computed<number>(() => {
-	// function timeRangeLength(): number {
 		return props.dayModels.length
 	})
 
@@ -89,9 +88,11 @@
 			<div id="legend">
 				<!-- Dummy first node to leave space for header -->
 				<p></p>
-				<p v-for="(hour, i) in timeRangeDisplay()">{{ hour }}</p>
+				<p v-for="(hour, i) in timeRangeDisplay()" :key="i">{{ hour }}</p>
 			</div>
-			<Day v-for="(day, i) in dayModels" :dayModel="day" :timeRangeLength="timeRangeLength" />
+			<div id="leftBgCol"></div>
+			<Day v-for="(day, i) in dayModels" :key="i" :dayModel="day" :timeRangeLength="timeRangeLength" />
+			<div id="rightBgCol"></div>
 		</div>
 	</div>
 	<!-- <Footer /> -->
@@ -106,49 +107,67 @@
 	}
 
 	#calendar {
+		$outerPad: 12px;
+		$innerPad: $outerPad / 2;
+
 		$legend-width: 10%;
+
 		// Each column width is the total window width minus the legend-width divided by the number of days
-		grid-template-columns: $legend-width repeat(v-bind('dayRangeLength'), calc((100% - $legend-width) / v-bind('dayRangeLength')));
+		$dayRange: v-bind('dayRangeLength');
+		$dayWidth: calc((100% - $legend-width) / $dayRange);
+
+		// $innerPad is provided later
+		// to maintain consistent col width.
+		$bgColWidth: calc($outerPad - $innerPad);
+
+		// Note: two cols exclusively for background-color
+		grid-template-columns: $legend-width $bgColWidth repeat($dayRange, $dayWidth) $bgColWidth;
 		display: grid;
 		justify-content: center;
 
-		$outerPad: 12px;
-
 		// HACK: Style background for the calendar
-		// Since we can't style around row gaps,
-		// we need to do some manual... adjustments.
+		// (Since we can't style under `column-gap`)
 		//
 		// Key iea: style the second col, first day of week,
 		// as if its the first column.
 		// The first actual column is the legend.
+
+		#leftBgCol, #rightBgCol {
+			background-color: rgba(black, 0.2);
+			margin-top: 40px;
+		}
+
+		#leftBgCol {
+			border-radius: 8px 0 0 8px;
+		}
+
+		#rightBgCol {
+			border-radius: 0 8px 8px 0;
+		}
+
 		&>div {
 
 			&::v-deep .incrementContainer {
-				padding: $outerPad 0;
+				// Account for doubling in inner cols
+				padding: $outerPad ($innerPad / 2);
 			}
+
+			// The following two padding adjustments
+			// help keep all cols the same width,
+			// as padding will shrink them.
 
 			// First day col
-			&:nth-child(2) {
-				// needs to know it's the "second" col
-				// (first in list of days)
+			&:nth-child(3) {
+				// This is here b/c it needs to know it's the "second" col
 				&::v-deep .incrementContainer {
-					border-radius: 8px 0 0 8px;
-					padding-left: $outerPad;
-				}
-			}
-
-			// Add spacing to inner elements
-			&:not(&:last-child) {
-				&::v-deep .incrementContainer {
-					padding-right: 5px;
+					padding-left: $innerPad;
 				}
 			}
 
 			// Last day col
-			&:last-child {
+			&:nth-last-child(2) {
 				&::v-deep .incrementContainer {
-					border-radius: 0 8px 8px 0;
-					padding-right: $outerPad;
+					padding-right: $innerPad;
 				}
 			}
 		}
@@ -164,7 +183,7 @@
 				// background-color: $primary;
 				grid-row: span 2;
 				font-size: 1.1rem;
-				padding-right: 20px;
+				margin-right: 15px;
 				text-align: right;
 
 				// Hidden empty first cell

--- a/src/components/calendar/Day.vue
+++ b/src/components/calendar/Day.vue
@@ -64,13 +64,17 @@
 		@mouseleave="mouseleave"
 	>
     	<h3>{{ dayModel.name }}</h3>
-		<Increment
-			v-for="i in timeRangeLength"
-			:index="i"
-			@child-mouseenter="childMouseenter"
-			@child-mousedown="childMousedown"
-			:class="{ selectedElement: intersections.get(i) }"
-		/>
+    	<div class="incrementContainer">
+			<Increment
+				v-for="i in timeRangeLength"
+				:index="i"
+				:key="i"
+				@child-mouseenter="childMouseenter"
+				@child-mousedown="childMousedown"
+				class="increment"
+				:class="{ selectedElement: intersections.get(i) }"
+			/>
+		</div>
 	</div>
 </template>
 
@@ -78,8 +82,15 @@
 
 	.day {
 		display: grid;
-		row-gap: 5px;
 		user-select: none;
+	}
+
+	.incrementContainer {
+		$pad: 20px;
+		background-color: rgba(black, 0.2);
+		padding: $pad 0;
+		display: grid;
+		row-gap: 5px;
 	}
 
 	// The selected "day" element
@@ -93,6 +104,7 @@
 		text-align: center;
 		height: 40px;
 		margin: 0;
+		background-color: white;
 	}
 
 </style>

--- a/src/components/calendar/Day.vue
+++ b/src/components/calendar/Day.vue
@@ -81,16 +81,23 @@
 <style scoped lang="scss">
 
 	.day {
-		display: grid;
 		user-select: none;
+
+		h3 {
+			font-size: 1.4rem;
+			text-align: center;
+			height: 40px;
+			margin: 0;
+			padding-top: 5px; // Bump a bit closer
+			font-weight: normal;
+			background-color: white;
+		}
 	}
 
 	.incrementContainer {
-		$pad: 20px;
-		background-color: rgba(black, 0.2);
-		padding: $pad 0;
 		display: grid;
 		row-gap: 5px;
+		background-color: rgba(black, 0.2);
 	}
 
 	// The selected "day" element
@@ -100,11 +107,5 @@
 		color: black;
 	}
 
-	h3 {
-		text-align: center;
-		height: 40px;
-		margin: 0;
-		background-color: white;
-	}
 
 </style>


### PR DESCRIPTION
## Background

Implements the rest of #42!

> Note: this PR takes place in the `/calendar` page :)

The main challenge of this PR was due to the limitation that `column-gap` [cannot be styled](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Columns/Styling_Columns#styling_column_boxes). We need a way to have consistent "padding" around the sides of the main calendar grid. 

In this PR, two cols were added to serve as blank background columns, with padding adjustments. If we simply apply `padding-left: $outerPad` on the first/last `Day` cols, the cells inside get squished. This method preserves consistent cell spacing :-)

Have an ASCII diagram:

```
[Old]
|| Legend || Day1 || ... || Day n ||
            ^                    ^
         add'l pad           add'l pad

[New]
|| Legend || BG ||  Day1 || ... || Day n || BG ||
             ^                                ^
         add'l pad                        add'l pad
```

## Contents
- Refactored how column logic works, with two new "background" cols
- Added `am/pm` logic
- Tweaked font styles and spacing to match Figma

## Preview & Breakdown

![Screenshot 2023-02-15 at 19-07-03 Noonalu](https://user-images.githubusercontent.com/2782749/219225506-39b7b0a9-bbfd-4b21-95ae-dc2f59f6b840.png)
