### PR TITLE
Unblock nlu-48 by adjusting for proxy

### DIFF
--- a/src/components/calendar/CalendarSetup.vue
+++ b/src/components/calendar/CalendarSetup.vue
@@ -17,9 +17,8 @@
 		    ]
 		}
 		const dataString = JSON.stringify(data)
-		fetch('https://api.noonalu.app/calendar', {
+		fetch('/api/calendar', {
 			method: 'POST',
-			mode: 'no-cors', // FIXME: needs CORS to set Content-Type
 			headers: new Headers({
 				'Content-Type': 'application/json',
 				'Content-Length': dataString.length.toString()

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -10,5 +10,23 @@ export default defineConfig({
 				additionalData: `@import "./src/styles/main";`
 			}
 		}
-	}
+	},
+	//settings for proxying requests during development
+	server: {
+    proxy: {
+      '/api': {
+
+				// // For development against local api:
+				// target:'http://localhost:5000',
+
+				// For development against live api:
+				target:'https://api.noonalu.app',
+				// Required additional setting to avoid cors 
+				changeOrigin:true,
+
+				// remove api from path of request
+				rewrite: (path) => path.replace(/^\/api/, ''),
+			},
+		}
+		}
 })


### PR DESCRIPTION
Unblock nlu-48 development. Switches how requests are sent to the server, so in dev they are ending up at the same dev server so the requests can be proxied to either a dev api or the live api.